### PR TITLE
'== None' --> 'is None'

### DIFF
--- a/pose_estimate/inference.py
+++ b/pose_estimate/inference.py
@@ -174,7 +174,7 @@ class Pose_estimation_rosnode():
         mid_x = (tlx + brx)/2
         mid_y = (tly + bry)/2
 
-        if self.points == None:
+        if self.points is None:
             return None, bbox
 
         #T = self.points[mid_x, mid_y]


### PR DESCRIPTION
If you use '==' on a numpy array, it will compare every element to the righthandside and yield an np.array of booleans.
e.g.
a = np.array([None,None])
In [4]: a is None
Out[4]: False

In [5]: a == None
Out[5]: array([ True,  True])

For me, this resulted in a ValueError.