### PR TITLE
Remove --no-clobber option

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,9 +3,9 @@
 # Note: Dockerfile achieves the same thing without this script
 echo "Fetching weights..."
 mkdir -p weights
-wget https://github.com/robberthofmanfm/yolo/releases/download/v0.0.1/obj19_detector.pt -o weights/detector.pt
-wget https://github.com/robberthofmanfm/yolo/releases/download/v0.0.1/encoder.npy -o weights/encoder.npy
-wget https://github.com/robberthofmanfm/yolo/releases/download/v0.0.1/obj_19_pose_estimator_model-epoch199.pt -o weights/pose_estimator.pt
+wget --no-clobber https://github.com/robberthofmanfm/yolo/releases/download/v0.0.1/obj19_detector.pt -O weights/detector.pt
+wget --no-clobber https://github.com/robberthofmanfm/yolo/releases/download/v0.0.1/encoder.npy -O weights/encoder.npy
+wget --no-clobber https://github.com/robberthofmanfm/yolo/releases/download/v0.0.1/obj_19_pose_estimator_model-epoch199.pt -O weights/pose_estimator.pt
 echo "Weights should be in ./weights folder"
 
 echo "Adding home folder to pythonpath - TODO should not be necessary"

--- a/install.sh
+++ b/install.sh
@@ -3,9 +3,9 @@
 # Note: Dockerfile achieves the same thing without this script
 echo "Fetching weights..."
 mkdir -p weights
-wget --no-clobber https://github.com/robberthofmanfm/yolo/releases/download/v0.0.1/obj19_detector.pt -o weights/detector.pt
-wget --no-clobber https://github.com/robberthofmanfm/yolo/releases/download/v0.0.1/encoder.npy -o weights/encoder.npy
-wget --no-clobber https://github.com/robberthofmanfm/yolo/releases/download/v0.0.1/obj_19_pose_estimator_model-epoch199.pt -o weights/pose_estimator.pt
+wget https://github.com/robberthofmanfm/yolo/releases/download/v0.0.1/obj19_detector.pt -o weights/detector.pt
+wget https://github.com/robberthofmanfm/yolo/releases/download/v0.0.1/encoder.npy -o weights/encoder.npy
+wget https://github.com/robberthofmanfm/yolo/releases/download/v0.0.1/obj_19_pose_estimator_model-epoch199.pt -o weights/pose_estimator.pt
 echo "Weights should be in ./weights folder"
 
 echo "Adding home folder to pythonpath - TODO should not be necessary"


### PR DESCRIPTION
`wget --no-clobber` resulted in trouble for me. If the file exists, it will write "File ‘obj_19_pose_estimator_model-epoch199.pt’ already there; not retrieving." to the file specified after `-o`. The pipeline will then yield all kinds of cryptic errors, because it is trying to interpret this text as a model.